### PR TITLE
Regex

### DIFF
--- a/stratagems/lua/lang/french/sfo_lua.tra
+++ b/stratagems/lua/lang/french/sfo_lua.tra
@@ -25,8 +25,8 @@
 @35="Force"
 @36="Tous les éléments"
 
-@100="Temps d'incantation :\|Temps d'incantation :" // should exactly match appropriate header in spell descriptions
-@101="Sphère :\|Sphère :" // should exactly match appropriate header in spell descriptions
+@100="Temps d'incantation[^:]*:" // should exactly match appropriate header in spell descriptions
+@101="Sph[^r]+re[^:]*:" // should exactly match appropriate header in spell descriptions
 @102="(Il s'agit d'une version de sort divin/druidique d'un sort normalement réservé aux sorts profanes.)"
 @103="(Il s'agit d'une version de sort profane d'un sort normalement réservé aux sorts divins/druidiques.)"
 @104="(Il s'agit d'une version de capacité spéciale d'un sort normalement réservé aux sorts divins/druidiques.)"
@@ -41,28 +41,34 @@
 @117="7ème niveau"
 @118="8ème niveau"
 @119="9ème niveau"
-@120="Avantages :\|Avantages :" // must exactly match string from kit descriptions
+@120="Avantages[^:]*:\|Inconv[^n]+nients[^:]*:" // must exactly match string from kit descriptions
 
-@130="Peut apprendre les sorts suivants en tant que sorts divins/druidiques :"
-@131="Apprend automatiquement les sorts suivants :"
-@132="Ajoute les sorts suivants à son livre de sorts profanes :"
+@130="Peut apprendre les sorts suivants en tant que sorts divins/druidiques :"
+@131="Apprend automatiquement les sorts suivants :"
+@132="Ajoute les sorts suivants à son livre de sorts profanes :"
 
-@900="Sphère :"
-@901="Peut apprendre les sorts divins/druidiques de ces sphères : "
-@910="Peut lancer des sorts druidiques" // should be the first few words of the description of spellcasting for, e.g., rangers and druids
-@911="Peut lancer des sorts de Druide" // use this as alternatives to @910 if your language doesn't have consistent strings across classes and games
-@912="Peut lancer des sorts de druide"
-@913="SFO_NOT_IN_USE_WURBLE"
-@914="SFO_NOT_IN_USE_WURBLE"
-@915="SFO_NOT_IN_USE_WURBLE"
+@900="Sph[^r]+re[^:]*:"
+@901="Peut apprendre les sorts divins/druidiques de ces sphères : "
+
+// should be the first few words of the description of spellcasting for, e.g., rangers and druids
+@910="Peut lancer quelques sorts divins [^ ]+ partir du niveau[^0-9]+[0-9]+\.?" // bgee/bg2ee/correctfrbg2 ranger @9557 (lvl 9)& iwdee @37106 (lvl 6)
+// use this as alternatives to @910 if your language doesn't have consistent strings across classes and games
+@911="Peut lancer des sorts divins\.?" // bgee/bg2ee/iwdee/correctfrBG2 druid @9560
+@912="Peut lancer des sorts de [dD]ruide\.?" // bg1ee @32341 + sod shaman @34084  & iwdee @40885 + bg2ee/correctfrBG2 shaman @103060
+@913="Peut lancer quelques sorts druidiques [^ ]+ partir du niveau[^0-9]+[0-9]+\.?" // iwdee @9557
+@914="Peut lancer des sorts druidiques [^ ]+ partir du niveau[^0-9]+[0-9]+\.?" // correctfrBG1 ranger 1009557
+@915="Peut lancer des sorts druidiques\.?" // correctfrBG1 shaman @1032341 @1034084
 @916="SFO_NOT_IN_USE_WURBLE"
 @917="SFO_NOT_IN_USE_WURBLE"
 @918="SFO_NOT_IN_USE_WURBLE"
 @919="SFO_NOT_IN_USE_WURBLE"
-@950="Peut lancer des sorts divins" // should be the first few words of the description of spellcasting for, e.g., paladins and clerics
-@951="Peut lancer des sorts de Prêtre" // use this as alternatives to @950 if your language doesn't have consistent strings across classes and games
-@952="Peut lancer des sorts de prêtre"
-@953="Peut lancer quelques sorts divins"
+
+// should be the first few words of the description of spellcasting for, e.g., paladins and clerics
+@950="Peut lancer des sorts divins\.?" // bgee/bg2ee cleric @24230 & bgee/bg2ee/iwdee/correctfrbg2 @9559
+// use this as alternatives to @950 if your language doesn't have consistent strings across classes and games
+@951="Peut lancer quelques sorts divins [^ ]+ partir du niveau[[^0-9]+[0-9]+\.?" // bgee/bg2ee/iwdee/correctfrbg2/correctfrBG1 paladin @9558 & iwdee @37128 correctfrbg2 @
+@952="Peut lancer des sorts de prêtre"// unused AFAIK
+@953="Peut lancer quelques sorts divins"// unused AFAIK
 @954="SFO_NOT_IN_USE_WURBLE"
 @955="SFO_NOT_IN_USE_WURBLE"
 @956="SFO_NOT_IN_USE_WURBLE"
@@ -79,6 +85,6 @@
 @100015="provenant de l'école LISTNAME"
 @100018="Niveau : "
 @100019="La liste complète des sorts profanes de l'école SCHOOL_PLACEHOLDER_2 est :"
-@100020="Avantages :\|Avantages :" // ,must be, verbatim, the appropriate string from class/kit descriptions
+@100020="Avantages[^:]*:" // ,must be, verbatim, the appropriate string from class/kit descriptions
 @100021="Sélectionnez au moins 1 sort de l'école SCHOOL_PLACEHOLDER pour continuer."
 @100022="Sélectionnez au moins NUMBER_PLACEHOLDER sorts de l'école SCHOOL_PLACEHOLDER pour continuer."

--- a/stratagems/lua/ui_bonus_spells.tph
+++ b/stratagems/lua/ui_bonus_spells.tph
@@ -241,12 +241,12 @@ BEGIN
 					REPLACE_TEXTUALLY "BONUS_SPELL_PLACEHOLDER" "%new_line%"
 				END ELSE 
 				PATCH_IF INDEX ("MAGE_SPELL_PLACEHOLDER" "%desc%") >=0 BEGIN
-					REPLACE_TEXTUALLY "MAGE_SPELL_PLACEHOLDER" "%new_line%"				
+					REPLACE_TEXTUALLY "MAGE_SPELL_PLACEHOLDER" "%new_line%"
 				END ELSE BEGIN
 					SPRINT adv_line @120
 					REPLACE_TEXTUALLY 
-						"^\(%adv_line%.*[%WNL%%LNL%%MNL%]\)\([^A-Za-z0-9]+\)\([A-Za-z0-9].*\)"
-						"%adv_line%%WNL%\2%new_line%%WNL%\2\3"			
+						"^\(%adv_line%\)\(.*[%WNL%%LNL%%MNL%]\)\([^A-Za-z0-9]+\)\([A-Za-z0-9].*\)"
+						"\1%WNL%\3%new_line%%WNL%\3\4"
 				END
 			END
 			STRING_SET_EVALUATE desc_strref "%desc%"

--- a/stratagems/lua/ui_spell_system_spheres.tph
+++ b/stratagems/lua/ui_spell_system_spheres.tph
@@ -169,7 +169,7 @@ BEGIN
 				READ_LONG 0x50 desc_strref
 				GET_STRREF desc_strref desc
 				INNER_PATCH_SAVE desc "%desc%" BEGIN	
-					REPLACE_TEXTUALLY "%sphere_base%.*" "%sphere_base% %text%"
+					REPLACE_TEXTUALLY "%sphere_base%.*" "\1 %text%"
 				END
 			BUT_ONLY
 			ACTION_IF desc_strref>0 BEGIN

--- a/stratagems/sfo2e/lib_splconv.tph
+++ b/stratagems/sfo2e/lib_splconv.tph
@@ -405,7 +405,7 @@ BEGIN
 		INNER_PATCH_SAVE new_desc "%old_desc%" BEGIN
 			REPLACE_TEXTUALLY "^%sphere_string%.*" ""
 			PATCH_IF new_ct>=0 BEGIN
-				REPLACE_TEXTUALLY "^%ct_string%[^%WNL%%LNL%%MNL%]*" "%ct_string% %new_ct%"
+				REPLACE_TEXTUALLY "^\(%ct_string%\)[^%WNL%%LNL%%MNL%]*" "\1 %new_ct%"
 			END
 		END
 		PATCH_IF "%old_type%" STR_EQ "wizard" BEGIN 
@@ -422,7 +422,7 @@ BEGIN
 		INNER_PATCH_SAVE new_desc "%old_desc%" BEGIN
 			REPLACE_TEXTUALLY "^%sphere_string%[^%WNL%%LNL%%MNL%]*[%WNL%%MNL%%LNL%]" ""
 			PATCH_IF new_ct>=0 BEGIN
-				REPLACE_TEXTUALLY "^%ct_string%[^%WNL%%LNL%%MNL%]*" "%ct_string% %new_ct%"
+				REPLACE_TEXTUALLY "^\(%ct_string%\)[^%WNL%%LNL%%MNL%]*" "\1 %new_ct%"
 			END
 		END
 		SPRINT new_desc "%new_desc%%WNL%%WNL%%p_to_w_string%"


### PR DESCRIPTION
Les modifs fine_weapons.tra sont nécessaires pour que la regex fonctionne.

Enfin... en toute rigueur, seule l'ajout d'espaces insécables dans "Non utilisable par :"  et "utilisable par :" est nécessaire, mais ça me paraissait incongru dele faire pour ces ":" là et pas les autres.

Pour les autres modifs 900 à 959 a priori elles ne sont pas utilisée pour SCS mais seuleemnt pour ToF.

Mais comme apparemment l'intention est d'avoir ce fichier identique dans les deux (j'ai vérifié.. et testé dans ToF) autant mettre les bonnes valeurs ici.

(Bonne nouvelle, il y a plein de fichiers identiques dans ToF. Je suppose que ce sera pareil pour SoM)